### PR TITLE
fix: Add token fallback to Phase 2.1 file management tools

### DIFF
--- a/github_mcp.py
+++ b/github_mcp.py
@@ -48,6 +48,7 @@ Features:
 from typing import Optional, List, Dict, Any
 from enum import Enum
 import json
+import os
 import httpx
 from datetime import datetime
 import base64
@@ -2147,6 +2148,8 @@ async def github_create_file(params: CreateFileInput) -> str:
         - Returns error if authentication fails (401/403)
         - Returns error if branch doesn't exist (404)
     """
+    auth_token = params.token or os.getenv('GITHUB_TOKEN')
+
     try:
         # Encode content to base64
         content_bytes = params.content.encode('utf-8')
@@ -2165,7 +2168,7 @@ async def github_create_file(params: CreateFileInput) -> str:
         data = await _make_github_request(
             f"repos/{params.owner}/{params.repo}/contents/{params.path}",
             method="PUT",
-            token=params.token,
+            token=auth_token,
             json=body
         )
         
@@ -2241,6 +2244,8 @@ async def github_update_file(params: UpdateFileInput) -> str:
         - Returns error if SHA doesn't match (409 conflict)
         - Returns error if authentication fails (401/403)
     """
+    auth_token = params.token or os.getenv('GITHUB_TOKEN')
+
     try:
         # Encode content to base64
         content_bytes = params.content.encode('utf-8')
@@ -2260,7 +2265,7 @@ async def github_update_file(params: UpdateFileInput) -> str:
         data = await _make_github_request(
             f"repos/{params.owner}/{params.repo}/contents/{params.path}",
             method="PUT",
-            token=params.token,
+            token=auth_token,
             json=body
         )
         
@@ -2342,6 +2347,8 @@ async def github_delete_file(params: DeleteFileInput) -> str:
         - Creates a commit that can be reverted if needed
         - File history is preserved in Git
     """
+    auth_token = params.token or os.getenv('GITHUB_TOKEN')
+
     try:
         # Prepare request body
         body = {
@@ -2356,7 +2363,7 @@ async def github_delete_file(params: DeleteFileInput) -> str:
         data = await _make_github_request(
             f"repos/{params.owner}/{params.repo}/contents/{params.path}",
             method="DELETE",
-            token=params.token,
+            token=auth_token,
             json=body
         )
         


### PR DESCRIPTION
## 🐛 Bug Fix: Token Authentication

Fixes token handling in Phase 2.1 file management tools to support environment variable fallback.

### 🔧 Changes

- Added `import os` for environment variable access
- Added `GITHUB_TOKEN` fallback logic to:
  - `github_create_file`
  - `github_update_file`
  - `github_delete_file`
- Updated all three tools to use `auth_token` in API calls

### 🐕🍖 Dogfooding Story #6

Discovered while attempting to use `github_update_file` to update the README! The new tools required an explicit token parameter instead of using the `GITHUB_TOKEN` environment variable like the existing tools.

**The irony:** We tried to use the file management tools to document themselves, which revealed they were broken! 😆

### ✅ Testing

- [x] Syntax validation passed
- [x] Pattern matches existing tools (github_create_issue, github_create_pull_request)
- [ ] Runtime testing pending after merge

### 📝 Related

- Closes #2 (Phase 2.1: File Management Tools)
- Follows up on PR #5

---

**This PR was created using `github_create_pull_request`** 🤯